### PR TITLE
Bugfix: dates properties is serialized as empty objects

### DIFF
--- a/src/camelcaseSerializer.test.js
+++ b/src/camelcaseSerializer.test.js
@@ -73,4 +73,16 @@ describe('CamelcaseSerializer', () => {
       expect(serializer.serialize(array)).toEqual([{ keyOne: 'value_one' }, { keyTwo: 'value_two_2' }]);
     });
   });
+
+  describe('when contains a date object', () => {
+    const date = new Date();
+    const object = { any_date: date };
+    const serializer = new CamelcaseSerializer();
+
+    it('returns date object as snake_case', () => {
+      expect(serializer.serialize(object)).toEqual({
+        anyDate: date
+      });
+    });
+  });
 });

--- a/src/keySerializer.js
+++ b/src/keySerializer.js
@@ -7,7 +7,7 @@ class KeySerializer extends Serializer {
   }
 
   getTransformedField(transform, key, value) {
-    if (value && typeof value === 'object') {
+    if (value && typeof value === 'object' && !(value instanceof Date)) {
       return { [this.keyTransform(key)]: this.serialize(transform(value)) };
     }
     return { [this.keyTransform(key)]: transform(value) };

--- a/src/snakecaseSerializer.test.js
+++ b/src/snakecaseSerializer.test.js
@@ -73,4 +73,16 @@ describe('SnakecaseSerializer', () => {
       expect(serializer.serialize(array)).toEqual([{ key_one: 'value_one' }, { key_two: 'value_two_2' }]);
     });
   });
+
+  describe('when contains a date object', () => {
+    const date = new Date();
+    const object = { anyDate: date };
+    const serializer = new SnakecaseSerializer();
+
+    it('returns date object as camelcase', () => {
+      expect(serializer.serialize(object)).toEqual({
+        any_date: date
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Bugfix: Date properties is serialized as empty objects

Date objects as
```
{
  myDate: new Date()
}
```
Is serialized as
```
{
  my_date: {}
}
``` 